### PR TITLE
Fix backdrop color in dark mode

### DIFF
--- a/.changeset/silly-dragons-fix.md
+++ b/.changeset/silly-dragons-fix.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/mui': patch
+---
+
+Fix backdrop color in dark mode.

--- a/packages/mui/src/components/MuiThemeProvider/theme.ts
+++ b/packages/mui/src/components/MuiThemeProvider/theme.ts
@@ -214,8 +214,9 @@ export const baseTheme: ThemeOptions = {
       styleOverrides: {
         root: ({ theme }) => ({
           backgroundColor:
-            theme.palette.mode === 'dark' ? '#000' : 'rgba(46,48,51,.38)',
-          opacity: 0.8,
+            theme.palette.mode === 'dark'
+              ? 'rgba(0,0,0,.8)'
+              : 'rgba(46,48,51,.304)',
         }),
         invisible: {
           backgroundColor: 'unset',


### PR DESCRIPTION
Mui made some changes to the backdrop styling causing us to loose our transparancy.

| Light | Dark |
|---|---|
| <img width="531" alt="image" src="https://user-images.githubusercontent.com/648527/201626584-94b36c1b-cf3f-490a-8ffc-a8a94f04458e.png"> | <img width="531" alt="image" src="https://user-images.githubusercontent.com/648527/201626688-a1795884-590d-4a4a-b395-4ed1a1962632.png"> |



**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
