### PR TITLE
Improve styling of dialogs in the scroll mode "body"

### DIFF
--- a/.changeset/cool-frogs-marry.md
+++ b/.changeset/cool-frogs-marry.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/mui': patch
+---
+
+Improve styling of dialogs in the scroll mode "body".

--- a/example-widget-mui/src/ThemePage/ThemePage.tsx
+++ b/example-widget-mui/src/ThemePage/ThemePage.tsx
@@ -365,6 +365,7 @@ export function CardsDemo() {
 
 export function DialogsDemo() {
   const [isOpen, setOpen] = useState(false);
+  const [isOpenScrollBody, setOpenScrollBody] = useState(false);
   const titleId = useId();
   const descriptionId = useId();
 
@@ -381,6 +382,14 @@ export function DialogsDemo() {
       <DemoContainer>
         <Button color="primary" fullWidth onClick={() => setOpen(true)}>
           Open Dialog
+        </Button>
+
+        <Button
+          color="primary"
+          fullWidth
+          onClick={() => setOpenScrollBody(true)}
+        >
+          Open Scroll "Body" Dialog
         </Button>
 
         <Dialog
@@ -405,6 +414,36 @@ export function DialogsDemo() {
               Accept
             </Button>
           </DialogActions>
+        </Dialog>
+
+        <Dialog
+          open={isOpenScrollBody}
+          scroll="body"
+          onClose={() => setOpenScrollBody(false)}
+        >
+          <DialogContent>
+            <DialogContentText>
+              Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+              nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+              erat, sed diam voluptua. At vero eos et accusam et justo duo
+              dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
+              sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
+              amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+              invidunt ut labore et dolore magna aliquyam erat, sed diam
+              voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
+              Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum
+              dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing
+              elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
+              magna aliquyam erat, sed diam voluptua. At vero eos et accusam et
+              justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+              takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor
+              sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod
+              tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+              voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
+              Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum
+              dolor sit amet.
+            </DialogContentText>
+          </DialogContent>
         </Dialog>
       </DemoContainer>
     </Box>

--- a/packages/mui/src/components/MuiThemeProvider/MuiThemeProvider.tsx
+++ b/packages/mui/src/components/MuiThemeProvider/MuiThemeProvider.tsx
@@ -86,10 +86,10 @@ export function chooseTheme(theme: string): ThemeOptions {
 
 function ElementMuiThemeProvider({ children }: PropsWithChildren<{}>) {
   const { theme } = useThemeSelection();
-  const [locale, setLocale] = useState(i18n.languages?.[0]);
+  const [locale, setLocale] = useState<string | undefined>(i18n.languages?.[0]);
 
   useEffect(() => {
-    const callback = () => setLocale(i18n.languages[0]);
+    const callback = () => setLocale(i18n.languages?.[0]);
 
     i18n.on('languageChanged', callback);
 
@@ -99,7 +99,7 @@ function ElementMuiThemeProvider({ children }: PropsWithChildren<{}>) {
   const muiTheme = useMemo(() => {
     const themeOptions = chooseTheme(theme);
     const localeOptions =
-      new Intl.Locale(locale).language === 'de' ? deDE : enUS;
+      locale && new Intl.Locale(locale).language === 'de' ? deDE : enUS;
 
     return createTheme(deepmerge(baseTheme, themeOptions), localeOptions);
   }, [locale, theme]);

--- a/packages/mui/src/components/MuiThemeProvider/theme.ts
+++ b/packages/mui/src/components/MuiThemeProvider/theme.ts
@@ -193,6 +193,12 @@ export const baseTheme: ThemeOptions = {
     // Dialogs have a different padding and font style
     MuiDialog: {
       styleOverrides: {
+        root: {
+          // Make margin smaller for scroll=body
+          '&& .MuiDialog-paperScrollBody': {
+            maxWidth: 600,
+          },
+        },
         paper: ({ theme }) => ({
           margin: theme.breakpoints.down('xs') ? '8px' : undefined,
         }),


### PR DESCRIPTION
This improves layout of dialog that have the scroll mode "body" by reducing the margin to 8 pixel as we have for the other scroll mode.

<img width="545" alt="image" src="https://user-images.githubusercontent.com/648527/203321435-a3887a67-15cc-4731-8641-3560c41a9444.png">

I also included a small improvement for my previous PR.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
