### PR TITLE
Permit null values for the displayname and avatar_url fields in the `m.room.member` event

### DIFF
--- a/.changeset/polite-windows-grow.md
+++ b/.changeset/polite-windows-grow.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/api': major
+---
+
+Permit `null` values for the `displayname` and `avatar_url` fields in the `m.room.member` event.

--- a/.changeset/purple-bees-flow.md
+++ b/.changeset/purple-bees-flow.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/testing': minor
+---
+
+Support a type filter for `clearRoomEvents()`.

--- a/packages/api/api-report.md
+++ b/packages/api/api-report.md
@@ -164,8 +164,8 @@ export type RoomEventOrNewContent<T = unknown> = RoomEvent<T | NewContentRelates
 // @public
 export type RoomMemberStateEventContent = {
     membership: MembershipState;
-    displayname?: string;
-    avatar_url?: string;
+    displayname?: string | null;
+    avatar_url?: string | null;
 };
 
 // @public

--- a/packages/api/src/api/extras/roomMember.test.ts
+++ b/packages/api/src/api/extras/roomMember.test.ts
@@ -36,6 +36,24 @@ describe('isValidRoomMemberStateEvent', () => {
     expect(isValidRoomMemberStateEvent(event)).toEqual(true);
   });
 
+  it('should permit null values', () => {
+    const event: StateEvent = {
+      content: {
+        membership: 'join',
+        displayname: null,
+        avatar_url: null,
+      },
+      event_id: 'event-id',
+      origin_server_ts: 0,
+      room_id: 'room-id',
+      sender: 'user-id',
+      state_key: '',
+      type: 'm.room.member',
+    };
+
+    expect(isValidRoomMemberStateEvent(event)).toEqual(true);
+  });
+
   it('should permit additional properties', () => {
     const event: StateEvent = {
       content: {

--- a/packages/api/src/api/extras/roomMember.ts
+++ b/packages/api/src/api/extras/roomMember.ts
@@ -40,16 +40,16 @@ export type RoomMemberStateEventContent = {
   /**
    * The display name for this user, if any.
    */
-  displayname?: string;
+  displayname?: string | null;
 
   /**
    * The avatar URL for this user, if any.
    */
-  avatar_url?: string;
+  avatar_url?: string | null;
 };
 
-function isStringOrUndefined(value: unknown): boolean {
-  return value === undefined || typeof value === 'string';
+function isStringUndefinedOrNull(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === 'string';
 }
 
 /**
@@ -74,11 +74,13 @@ export function isValidRoomMemberStateEvent(
     return false;
   }
 
-  if (!isStringOrUndefined(content.displayname)) {
+  if (!isStringUndefinedOrNull(content.displayname)) {
     return false;
   }
 
-  if (!isStringOrUndefined(content.avatar_url)) {
+  // the avatar_url shouldn't be null, but some implementations
+  // set it as a valid value
+  if (!isStringUndefinedOrNull(content.avatar_url)) {
     return false;
   }
 

--- a/packages/testing/api-report.md
+++ b/packages/testing/api-report.md
@@ -15,7 +15,9 @@ export type MockedWidgetApi = {
     stop: () => void;
     mockSendRoomEvent<T = unknown>(event: RoomEvent<T>): RoomEvent<T>;
     mockSendStateEvent<T = unknown>(event: StateEvent<T>): StateEvent<T>;
-    clearRoomEvents(): void;
+    clearRoomEvents(opts?: {
+        type?: string;
+    }): void;
     clearStateEvents(opts?: {
         type?: string;
     }): void;

--- a/packages/testing/src/api/mockWidgetApi.test.ts
+++ b/packages/testing/src/api/mockWidgetApi.test.ts
@@ -222,6 +222,17 @@ describe('receiveRoomEvents', () => {
       widgetApi.receiveRoomEvents('com.example.test1')
     ).resolves.toEqual([]);
   });
+
+  it('should not receive events after clearing a selected type', async () => {
+    widgetApi.clearRoomEvents({ type: 'com.example.test1' });
+
+    await expect(
+      widgetApi.receiveRoomEvents('com.example.test1')
+    ).resolves.toEqual([]);
+    await expect(
+      widgetApi.receiveRoomEvents('com.example.test2')
+    ).resolves.toEqual([expect.objectContaining({ event_id: 'event-2' })]);
+  });
 });
 
 describe('observeRoomEvents', () => {

--- a/packages/testing/src/api/mockWidgetApi.ts
+++ b/packages/testing/src/api/mockWidgetApi.ts
@@ -63,8 +63,11 @@ export type MockedWidgetApi = {
   /**
    * Removes all room events from the mock. Future reads of room events will be
    * empty.
+   *
+   * @param opts - Options for deleting.
+   *               Use `type` to restrict which events are deleted.
    */
-  clearRoomEvents(): void;
+  clearRoomEvents(opts?: { type?: string }): void;
 
   /**
    * Removes all state events from the mock. Future reads of state events will be
@@ -110,7 +113,7 @@ export function mockWidgetApi({
   widgetId?: string;
 } = {}): MockedWidgetApi {
   const roomEventSubject = new Subject<RoomEvent>();
-  const roomEvents: RoomEvent[] = [];
+  let roomEvents: RoomEvent[] = [];
   let stateEvents: StateEvent[] = [];
   const stateEventSubject = new Subject<StateEvent>();
   const stopSubject = new Subject<void>();
@@ -144,8 +147,12 @@ export function mockWidgetApi({
     return event;
   };
 
-  const clearRoomEvents = () => {
-    roomEvents.length = 0;
+  const clearRoomEvents = (opts?: { type?: string }) => {
+    if (typeof opts?.type === 'string') {
+      roomEvents = roomEvents.filter((ev) => ev.type !== opts.type);
+    } else {
+      roomEvents.length = 0;
+    }
   };
 
   const clearStateEvents = (opts?: { type?: string }) => {


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
