### PR TITLE
Fix generated avatar URLs

### DIFF
--- a/.changeset/gold-snails-attack.md
+++ b/.changeset/gold-snails-attack.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/mui': patch
+---
+
+Fix issue with generated avatar URLs.

--- a/packages/mui/src/components/ElementAvatar/createAvatarUrl.ts
+++ b/packages/mui/src/components/ElementAvatar/createAvatarUrl.ts
@@ -20,11 +20,13 @@ export function createAvatarUrl(
   url: string,
   { size = 60 }: { size?: number } = {}
 ): string {
-  const mxcUrl = new URL(url);
+  const mxcPrefix = 'mxc://';
 
-  if (mxcUrl.protocol.toLowerCase() !== 'mxc:') {
+  if (url.indexOf(mxcPrefix) !== 0) {
     return url;
   }
+
+  const mxcUrl = url.slice(mxcPrefix.length);
 
   // TODO: Instead of retrieving the home server from an env variable, it would
   // be good to get this passed by the widget host, e.g. as an URL parameter.
@@ -38,7 +40,7 @@ export function createAvatarUrl(
     'https://matrix-client.matrix.org'
   );
   const imageUrl = new URL(
-    `/_matrix/media/r0/thumbnail/${mxcUrl.hostname}${mxcUrl.pathname}?width=${size}&height=${size}&method=crop`,
+    `/_matrix/media/r0/thumbnail/${mxcUrl}?width=${size}&height=${size}&method=crop`,
     homeServer
   );
   return imageUrl.toString();


### PR DESCRIPTION
The URL class has different behavior in Node that it has in the browser, where it is unable to handle custom protocols. To avoid this issue we don't use it here.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
