### PR TITLE
Fix build pipeline for the container images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,13 +211,13 @@ jobs:
 
           # try to fetch the manifest. exits with status 0 if the
           # tag exists and with status 1 if not.
-          OUTPUT=$(docker manifest inspect $DOCKER_IMAGE:$SEARCH_TAG 2>&1)
+          OUTPUT=$(docker buildx imagetools inspect $DOCKER_IMAGE:$SEARCH_TAG 2>&1)
           RESULT=$([[ "$?" == 0 ]] && echo "true" || echo "false")
 
           echo $OUTPUT
 
           # throw an error if the output is unexpected, e.g. due to a network problem.
-          if [[ $RESULT == "false" ]] && [[ $OUTPUT != "manifest unknown" ]]; then
+          if [[ $RESULT == "false" ]] && [[ $OUTPUT != "ERROR: $DOCKER_IMAGE:$SEARCH_TAG: not found" ]]; then
             echo "Unexpected error"
             exit 1
           fi


### PR DESCRIPTION
We get the following error when we check if the docker image tag already exists in the `main` branch:
![image](https://github.com/nordeck/matrix-widget-toolkit/assets/720821/aa958139-b755-44d4-b502-5e927c738fc5)

This is related to https://github.com/orgs/community/discussions/45779. Let's switch from `docker manifest inspect` to `docker buildx imagetools inspect`.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
