### PR TITLE
Sort the emoji font families last

### DIFF
--- a/.changeset/long-wolves-approve.md
+++ b/.changeset/long-wolves-approve.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/mui': patch
+---
+
+Sort the emoji font families last.

--- a/packages/mui/src/components/MuiThemeProvider/theme.ts
+++ b/packages/mui/src/components/MuiThemeProvider/theme.ts
@@ -20,12 +20,12 @@ import { getEnvironment } from './environment';
 
 const fontFamily = [
   'Inter',
-  'Twemoji',
-  '"Apple Color Emoji"',
-  '"Segoe UI Emoji"',
   'Arial',
   'Helvetica',
   'sans-serif',
+  'Twemoji',
+  '"Apple Color Emoji"',
+  '"Segoe UI Emoji"',
   '"Noto Color Emoji"',
 ].join(',');
 


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

Emoji fonts should be sorted last because they will otherwise be chosen as a fallback if the primary font (in our case `Inter`) is not available or not loaded. This was visible in https://github.com/nordeck/matrix-meetings when pasting the email-template on Mac OS:

Copy the following text:
<img width="300" alt="image" src="https://github.com/nordeck/matrix-widget-toolkit/assets/720821/edd4f8f3-d5e2-4e94-91b7-35ac3b160e8d">

<table>
<tr>
<th>Before: broken rendering with emoji font</th>
<th>After: correct with arial</th>
</tr>
<tr>
<td>
<img alt="image" src="https://github.com/nordeck/matrix-widget-toolkit/assets/720821/84b49ff4-75b6-40ea-95b5-76d2e4e5725f">
</td>
<td>
<img alt="image" src="https://github.com/nordeck/matrix-widget-toolkit/assets/720821/40bc240b-f765-4cdb-a7d4-5be3c5ee0d7a">
</td>
</tr>
</table>


<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [x] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
