### PR TITLE
Implement the download_file widget action

### DIFF
--- a/.changeset/sweet-jeans-smile.md
+++ b/.changeset/sweet-jeans-smile.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/api': minor
+---
+
+Add support for the download_file widget action

--- a/example-widget-mui/README.md
+++ b/example-widget-mui/README.md
@@ -17,7 +17,7 @@ The widget demonstrates:
 - How to read related events ([`Event Relations`](./src/RelationsPage/RelationsPage.tsx)).
 - How to search the User Directory ([`User Directory and Invitations`](./src/InvitationsPage/InvitationsPage.tsx)).
 - How to use the UI components to match the style of Element ([`Theme`](./src/ThemePage/ThemePage.tsx)).
-- How to upload files to the media repository ([`Upload File`](./src/UploadImagePage/UploadImagePage.tsx)).
+- How to upload and download files to the media repository ([`Up- and download image`](./src/ImagePage/ImagePage.tsx)).
 
 ## Demo
 

--- a/example-widget-mui/package.json
+++ b/example-widget-mui/package.json
@@ -17,7 +17,7 @@
     "i18next-http-backend": "^2.5.2",
     "joi": "^17.13.3",
     "lodash": "^4.17.21",
-    "matrix-widget-api": "^1.7.0",
+    "matrix-widget-api": "^1.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^15.0.0",

--- a/example-widget-mui/src/App/App.tsx
+++ b/example-widget-mui/src/App/App.tsx
@@ -24,6 +24,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { AllRoomsPage } from '../AllRoomsPage';
 import { DicePage } from '../DicePage';
 import { IdentityPage } from '../IdentityPage';
+import { ImagePage } from '../ImagePage';
 import { InvitationsPage } from '../InvitationsPage';
 import { ModalDialog, ModalPage } from '../ModalPage';
 import { NavigationPage } from '../NavigationPage';
@@ -31,7 +32,6 @@ import { PowerLevelsPage } from '../PowerLevelsPage';
 import { RelationsPage } from '../RelationsPage';
 import { RoomPage } from '../RoomPage';
 import { ThemePage } from '../ThemePage';
-import { UploadImagePage } from '../UploadImagePage';
 import { WelcomePage } from '../WelcomePage';
 
 export function App({
@@ -65,7 +65,7 @@ export function App({
               <Route path="/relations" element={<RelationsPage />} />
               <Route path="/invitations" element={<InvitationsPage />} />
               <Route path="/theme" element={<ThemePage />} />
-              <Route path="/uploadImage" element={<UploadImagePage />} />
+              <Route path="/image" element={<ImagePage />} />
             </Routes>
           </MuiWidgetApiProvider>
         </Suspense>

--- a/example-widget-mui/src/ImagePage/Image.tsx
+++ b/example-widget-mui/src/ImagePage/Image.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useWidgetApi } from '@matrix-widget-toolkit/react';
+import React, { useCallback, useEffect, useState } from 'react';
+
+type ImageProps = {
+  alt?: string;
+  /**
+   * MXC URI of the image that should be shown
+   */
+  contentUrl: string;
+};
+
+/**
+ * Component that loads the image from the content repository and displays it.
+ */
+export const Image: React.FC<ImageProps> = function ({
+  contentUrl,
+  ...imageProps
+}) {
+  const [dataUrl, setDataUrl] = useState<string>();
+  const widgetApi = useWidgetApi();
+
+  const handleLoad = useCallback(() => {
+    if (dataUrl) {
+      URL.revokeObjectURL(dataUrl);
+    }
+  }, [dataUrl]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const result = await widgetApi.downloadFile(contentUrl);
+
+        if (!(result.file instanceof Blob)) {
+          throw new Error('Got non Blob file response');
+        }
+
+        const downloadedFileDataUrl = URL.createObjectURL(result.file);
+        setDataUrl(downloadedFileDataUrl);
+      } catch (error) {
+        console.log('Error downloading file', error);
+      }
+    })();
+  }, [contentUrl]);
+
+  if (dataUrl === undefined) {
+    return null;
+  }
+
+  return <img {...imageProps} src={dataUrl} onLoad={handleLoad} />;
+};

--- a/example-widget-mui/src/ImagePage/ImageListView.tsx
+++ b/example-widget-mui/src/ImagePage/ImageListView.tsx
@@ -33,6 +33,7 @@ import {
   UploadedImageEvent,
   isValidUploadedImage,
 } from '../events';
+import { Image } from './Image';
 
 export const ImageListView = (): ReactElement => {
   const widgetApi = useWidgetApi();
@@ -75,13 +76,9 @@ export const ImageListView = (): ReactElement => {
             {imageNames.length > 0 &&
               imageNames.map((image) => (
                 <ImageListItem key={image.event_id}>
-                  <img
-                    src={`${getHttpUriForMxc(
-                      image.content.url,
-                      widgetApi.widgetParameters.baseUrl,
-                    )}?w=164&h=164&fit=crop&auto=format`}
+                  <Image
                     alt={image.content.name}
-                    loading="lazy"
+                    contentUrl={image.content.url}
                   />
                   <ImageListItemBar
                     title={image.content.name}

--- a/example-widget-mui/src/ImagePage/ImagePage.test.tsx
+++ b/example-widget-mui/src/ImagePage/ImagePage.test.tsx
@@ -27,7 +27,7 @@ import { ComponentType, PropsWithChildren, act } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { ROOM_EVENT_UPLOADED_IMAGE } from '../events';
 import { StoreProvider } from '../store';
-import { UploadImagePage } from './UploadImagePage';
+import { ImagePage } from './ImagePage';
 
 let widgetApi: MockedWidgetApi;
 let wrapper: ComponentType<PropsWithChildren<{}>>;
@@ -46,9 +46,9 @@ beforeEach(() => {
   );
 });
 
-describe('<UploadImagePage>', () => {
+describe('<ImagePage>', () => {
   it('should render without exploding', async () => {
-    render(<UploadImagePage />, { wrapper });
+    render(<ImagePage />, { wrapper });
 
     expect(
       screen.getByRole('link', { name: /back to navigation/i }),
@@ -66,7 +66,7 @@ describe('<UploadImagePage>', () => {
   });
 
   it('should have no accessibility violations', async () => {
-    const { container } = render(<UploadImagePage />, { wrapper });
+    const { container } = render(<ImagePage />, { wrapper });
 
     expect(
       screen.getByRole('heading', { name: /upload file/i }),
@@ -83,7 +83,7 @@ describe('<UploadImagePage>', () => {
   });
 
   it('should request the capabilities', async () => {
-    render(<UploadImagePage />, { wrapper });
+    render(<ImagePage />, { wrapper });
 
     expect(widgetApi.requestCapabilities).toHaveBeenCalledWith([
       WidgetEventCapability.forRoomEvent(
@@ -104,7 +104,7 @@ describe('<UploadImagePage>', () => {
   });
 
   it('should say that no images are loaded yet', async () => {
-    render(<UploadImagePage />, { wrapper });
+    render(<ImagePage />, { wrapper });
 
     await expect(
       screen.findByText(/no images uploaded to this room yet/i),
@@ -118,7 +118,7 @@ describe('<UploadImagePage>', () => {
       url: 'http://example.com/image.png',
     });
 
-    render(<UploadImagePage />, { wrapper });
+    render(<ImagePage />, { wrapper });
 
     await expect(
       screen.findByRole('img', { name: /image.png/i }),

--- a/example-widget-mui/src/ImagePage/ImagePage.test.tsx
+++ b/example-widget-mui/src/ImagePage/ImagePage.test.tsx
@@ -37,6 +37,8 @@ afterEach(() => widgetApi.stop());
 beforeEach(() => {
   widgetApi = mockWidgetApi();
 
+  global.URL.createObjectURL = jest.fn().mockReturnValue('http://...');
+
   wrapper = ({ children }: PropsWithChildren<{}>) => (
     <WidgetApiMockProvider value={widgetApi}>
       <StoreProvider>
@@ -44,6 +46,10 @@ beforeEach(() => {
       </StoreProvider>
     </WidgetApiMockProvider>
   );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
 });
 
 describe('<ImagePage>', () => {
@@ -95,6 +101,7 @@ describe('<ImagePage>', () => {
         ROOM_EVENT_UPLOADED_IMAGE,
       ),
       WidgetApiFromWidgetAction.MSC4039UploadFileAction,
+      WidgetApiFromWidgetAction.MSC4039DownloadFileAction,
       WidgetApiFromWidgetAction.MSC4039GetMediaConfigAction,
     ]);
 
@@ -115,7 +122,7 @@ describe('<ImagePage>', () => {
     widgetApi.sendRoomEvent(ROOM_EVENT_UPLOADED_IMAGE, {
       name: 'image.png',
       size: 123,
-      url: 'http://example.com/image.png',
+      url: 'mxc://...',
     });
 
     render(<ImagePage />, { wrapper });

--- a/example-widget-mui/src/ImagePage/ImagePage.tsx
+++ b/example-widget-mui/src/ImagePage/ImagePage.tsx
@@ -49,7 +49,7 @@ import { ROOM_EVENT_UPLOADED_IMAGE, UploadedImageEvent } from '../events';
 /**
  * A component that showcases how to upload image files and render them in a widget.
  */
-export const UploadImagePage = (): ReactElement => {
+export const ImagePage = (): ReactElement => {
   const widgetApi = useWidgetApi();
   const [errorDialogOpen, setErrorDialogOpen] = useState<boolean>(false);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
@@ -137,10 +137,11 @@ export const UploadImagePage = (): ReactElement => {
               ROOM_EVENT_UPLOADED_IMAGE,
             ),
             WidgetApiFromWidgetAction.MSC4039UploadFileAction,
+            WidgetApiFromWidgetAction.MSC4039DownloadFileAction,
             WidgetApiFromWidgetAction.MSC4039GetMediaConfigAction,
           ]}
         >
-          {/* 
+          {/*
           The StoreProvider is located here to keep the example small. Normal
           applications would locate it outside of the router to establish a
           single, global store.

--- a/example-widget-mui/src/ImagePage/ImagePage.tsx
+++ b/example-widget-mui/src/ImagePage/ImagePage.tsx
@@ -71,6 +71,7 @@ export const ImagePage = (): ReactElement => {
   const handleFileUpload = useCallback(() => {
     const uploadImage = async () => {
       if (selectedFile) {
+        setLoading(true);
         if (!selectedFile.type.startsWith('image/')) {
           setErrorMessage(
             'Please select a valid image file. You can upload any image format that is supported by the browser.',
@@ -103,18 +104,17 @@ export const ImagePage = (): ReactElement => {
           const responseUploadMedia = await widgetApi.uploadFile(selectedFile);
           const url = responseUploadMedia.content_uri;
 
-          setLoading(true);
           await widgetApi.sendRoomEvent<UploadedImageEvent>(
             ROOM_EVENT_UPLOADED_IMAGE,
             { name: selectedFile.name, size: selectedFile.size, url },
           );
-          setLoading(false);
-          setSelectedFile(null);
 
-          return;
+          setSelectedFile(null);
         } catch (error) {
           setErrorMessage('An error occurred during file upload: ' + error);
           setErrorDialogOpen(true);
+        } finally {
+          setLoading(false);
         }
       }
     };

--- a/example-widget-mui/src/ImagePage/index.ts
+++ b/example-widget-mui/src/ImagePage/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { UploadImagePage } from './UploadImagePage';
+export { ImagePage } from './ImagePage';

--- a/example-widget-mui/src/NavigationPage/NavigationPage.tsx
+++ b/example-widget-mui/src/NavigationPage/NavigationPage.tsx
@@ -110,9 +110,9 @@ export const NavigationPage = (): ReactElement => {
           design of Element"
         />
         <NavigationItem
-          to="/uploadImage"
-          title="Upload File"
-          description="Example for uploading an image file"
+          to="/image"
+          title="Up- and download image"
+          description="Example for up- and downloading an image file"
         />
       </List>
     </Box>

--- a/packages/api/api-report.api.md
+++ b/packages/api/api-report.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Capability } from 'matrix-widget-api';
+import { IDownloadFileActionFromWidgetResponseData } from 'matrix-widget-api';
 import { IGetMediaConfigActionFromWidgetResponseData } from 'matrix-widget-api';
 import { IModalWidgetCreateData } from 'matrix-widget-api';
 import { IModalWidgetOpenRequestDataButton } from 'matrix-widget-api';
@@ -271,6 +272,7 @@ export type WidgetApi = {
     }>;
     getMediaConfig(): Promise<IGetMediaConfigActionFromWidgetResponseData>;
     uploadFile(file: XMLHttpRequestBodyInit): Promise<IUploadFileActionFromWidgetResponseData>;
+    downloadFile(contentUrl: string): Promise<IDownloadFileActionFromWidgetResponseData>;
 };
 
 // @public
@@ -281,6 +283,7 @@ export class WidgetApiImpl implements WidgetApi {
     widgetParameters: WidgetParameters, { capabilities, supportStandalone }?: WidgetApiOptions);
     closeModal<T extends IModalWidgetReturnData>(data?: T): Promise<void>;
     static create({ capabilities, supportStandalone, }?: WidgetApiOptions): Promise<WidgetApi>;
+    downloadFile(contentUrl: string): Promise<IDownloadFileActionFromWidgetResponseData>;
     getMediaConfig(): Promise<IGetMediaConfigActionFromWidgetResponseData>;
     getWidgetConfig<T extends IWidgetApiRequestData>(): Readonly<WidgetConfig<T> | undefined>;
     hasCapabilities(capabilities: Array<WidgetEventCapability | Capability>): boolean;

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -28,7 +28,7 @@
     "generate-api-report": "tsc && api-extractor run --verbose --local"
   },
   "dependencies": {
-    "matrix-widget-api": "^1.7.0",
+    "matrix-widget-api": "^1.9.0",
     "qs": "^6.13.0",
     "rxjs": "^7.8.1"
   },

--- a/packages/api/src/api/WidgetApiImpl.ts
+++ b/packages/api/src/api/WidgetApiImpl.ts
@@ -16,6 +16,7 @@
 
 import {
   Capability,
+  IDownloadFileActionFromWidgetResponseData,
   IGetMediaConfigActionFromWidgetResponseData,
   IModalWidgetCreateData,
   IModalWidgetOpenRequestDataButton,
@@ -798,5 +799,12 @@ export class WidgetApiImpl implements WidgetApi {
     file: XMLHttpRequestBodyInit,
   ): Promise<IUploadFileActionFromWidgetResponseData> {
     return await this.matrixWidgetApi.uploadFile(file);
+  }
+
+  /** {@inheritdoc WidgetApi.downloadFile}  */
+  async downloadFile(
+    contentUrl: string,
+  ): Promise<IDownloadFileActionFromWidgetResponseData> {
+    return await this.matrixWidgetApi.downloadFile(contentUrl);
   }
 }

--- a/packages/api/src/api/types.ts
+++ b/packages/api/src/api/types.ts
@@ -16,6 +16,7 @@
 
 import {
   Capability,
+  IDownloadFileActionFromWidgetResponseData,
   IGetMediaConfigActionFromWidgetResponseData,
   IModalWidgetCreateData,
   IModalWidgetOpenRequestDataButton,
@@ -560,6 +561,15 @@ export type WidgetApi = {
   uploadFile(
     file: XMLHttpRequestBodyInit,
   ): Promise<IUploadFileActionFromWidgetResponseData>;
+
+  /**
+   * Download a file to the media repository on the homeserver.
+   * @param contentUrl - MXC URI of the file to download
+   * @returns resolves to an object with: file - the file contents
+   */
+  downloadFile(
+    contentUrl: string,
+  ): Promise<IDownloadFileActionFromWidgetResponseData>;
 
   // TODO: sendSticker, setAlwaysOnScreen
 };

--- a/packages/mui/package.json
+++ b/packages/mui/package.json
@@ -51,7 +51,7 @@
     "i18next-browser-languagedetector": "^8.0.0",
     "i18next-resources-to-backend": "^1.2.1",
     "lodash": "^4.17.21",
-    "matrix-widget-api": "^1.7.0",
+    "matrix-widget-api": "^1.9.0",
     "react": "^18.2.0",
     "react-i18next": "^15.0.0",
     "react-use": "^17.5.1"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@matrix-widget-toolkit/api": "^3.2.2",
-    "matrix-widget-api": "^1.7.0",
+    "matrix-widget-api": "^1.9.0",
     "react": "^18.2.0",
     "react-error-boundary": "^3.1.4",
     "react-use": "^17.5.1"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@matrix-widget-toolkit/api": "^3.3.0",
     "lodash": "^4.17.21",
-    "matrix-widget-api": "^1.7.0",
+    "matrix-widget-api": "^1.9.0",
     "rxjs": "^7.8.1"
   },
   "repository": {

--- a/packages/testing/src/api/mockWidgetApi.ts
+++ b/packages/testing/src/api/mockWidgetApi.ts
@@ -235,7 +235,9 @@ export function mockWidgetApi(opts?: {
     uploadFile: jest.fn().mockResolvedValue({
       content_uri: 'mxc://...',
     }),
-    downloadFile: jest.fn(),
+    downloadFile: jest.fn().mockResolvedValue({
+      file: new Blob(['image content'], { type: 'image/png' }),
+    }),
   };
 
   widgetApi.receiveRoomEvents.mockImplementation(async (type, options) => {

--- a/packages/testing/src/api/mockWidgetApi.ts
+++ b/packages/testing/src/api/mockWidgetApi.ts
@@ -235,6 +235,7 @@ export function mockWidgetApi(opts?: {
     uploadFile: jest.fn().mockResolvedValue({
       content_uri: 'mxc://...',
     }),
+    downloadFile: jest.fn(),
   };
 
   widgetApi.receiveRoomEvents.mockImplementation(async (type, options) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8623,10 +8623,10 @@ matcher-collection@^2.0.0:
     "@types/minimatch" "^3.0.3"
     minimatch "^3.0.2"
 
-matrix-widget-api@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.7.0.tgz#ae3b44380f11bb03519d0bf0373dfc3341634667"
-  integrity sha512-dzSnA5Va6CeIkyWs89xZty/uv38HLyfjOrHGbbEikCa2ZV0HTkUNtrBMKlrn4CRYyDJ6yoO/3ssRwiR0jJvOkQ==
+matrix-widget-api@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.9.0.tgz#884136b405bd3c56e4ea285095c9e01ec52b6b1f"
+  integrity sha512-au8mqralNDqrEvaVAkU37bXOb8I9SCe+ACdPk11QWw58FKstVq31q2wRz+qWA6J+42KJ6s1DggWbG/S3fEs3jw==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"


### PR DESCRIPTION
Implements usage of the `download_file` action of the Widget API.
See [MSC4039](https://github.com/matrix-org/matrix-spec-proposals/pull/4039) .

Also moves the `UploadImagePage` page to `ImagePage` since it now demos up- and download of content.

Needs https://github.com/matrix-org/matrix-react-sdk/pull/12931

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [x] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
