### PR TITLE
add fullscreen options to baseTheme

### DIFF
--- a/.changeset/famous-frogs-eat.md
+++ b/.changeset/famous-frogs-eat.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/mui': patch
+---
+
+Ensure that popover elements are also visible in fullscreen at all times

--- a/packages/mui/src/components/MuiThemeProvider/theme.ts
+++ b/packages/mui/src/components/MuiThemeProvider/theme.ts
@@ -231,14 +231,27 @@ export const baseTheme: ThemeOptions = {
       },
     },
 
-    // Tooltips have a darker background
+    // Tooltips are fullscreen-aware
+    MuiMenu: {
+      defaultProps: {
+        container: document.fullscreenElement ?? document.body,
+      },
+    },
     MuiTooltip: {
+      // Tooltips have a darker background
       styleOverrides: {
         tooltip: ({ theme }) => ({
           fontSize: defaultTheme.typography.pxToRem(12),
           backgroundColor: 'rgb(33, 38, 44)',
           padding: theme.spacing(1),
         }),
+      },
+
+      // Tooltips are fullscreen-aware
+      defaultProps: {
+        PopperProps: {
+          container: document.fullscreenElement ?? document.body,
+        },
       },
     },
 

--- a/packages/mui/src/components/MuiThemeProvider/theme.ts
+++ b/packages/mui/src/components/MuiThemeProvider/theme.ts
@@ -254,7 +254,12 @@ export const baseTheme: ThemeOptions = {
         },
       },
     },
-
+    // Tooltips are fullscreen-aware
+    MuiPopover: {
+      defaultProps: {
+        container: document.fullscreenElement ?? document.body,
+      },
+    },
     // Buttons have to ripple but have the default keyboard focus ring instead
     MuiButtonBase: {
       defaultProps: {


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

The idea of this PR is to add these options globally to the theme, so Menues and Tooltips in an application embedding a widget (such as the neoboard react sdk) directly work properly when fullscreened.

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
