### PR TITLE
Fix example widget image list layout

### DIFF
--- a/example-widget-mui/src/ImagePage/Image.tsx
+++ b/example-widget-mui/src/ImagePage/Image.tsx
@@ -62,5 +62,12 @@ export const Image: React.FC<ImageProps> = function ({
     return null;
   }
 
-  return <img {...imageProps} src={dataUrl} onLoad={handleLoad} />;
+  return (
+    <img
+      style={{ width: '100%' }}
+      {...imageProps}
+      src={dataUrl}
+      onLoad={handleLoad}
+    />
+  );
 };


### PR DESCRIPTION
Images were overflowing in the image list. This sets the image list explicitly, so that they fit into their containers.

 | Before | After |
| --- | --- |
| ![image-list-before](https://github.com/user-attachments/assets/b55d7929-a9dc-4190-88b6-2ef23b40360a) | ![image-list-after](https://github.com/user-attachments/assets/cef48e37-075d-4693-b37c-fd375a9e82b0) |

No changeset, because [we ignore the example widget ](https://github.com/nordeck/matrix-widget-toolkit/blob/main/.changeset/config.json#L9)


<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
