### PR TITLE
Align widget and Element colors

### DIFF
--- a/.changeset/poor-carrots-yawn.md
+++ b/.changeset/poor-carrots-yawn.md
@@ -2,4 +2,4 @@
 '@matrix-widget-toolkit/mui': patch
 ---
 
-Align widget and Elementgreen and red colors
+Update default primary and error colors to match current Element Web theme.

--- a/.changeset/poor-carrots-yawn.md
+++ b/.changeset/poor-carrots-yawn.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/mui': patch
+---
+
+Align widget and Elementgreen and red colors

--- a/packages/mui/README.md
+++ b/packages/mui/README.md
@@ -79,7 +79,9 @@ import { EventDirection, WidgetEventCapability } from 'matrix-widget-api';
 
 ## Customization
 
-You can override the primary color by setting the `REACT_APP_PRIMARY_COLOR` environment variable.
+You can override the light primary color by setting the `REACT_APP_LIGHT_PRIMARY_COLOR` environment variable.
+
+You can override the dark primary color by setting the `REACT_APP_DARK_PRIMARY_COLOR` environment variable.
 
 > **Warning** Choosing a different primary color might result in not meeting contrast requirements for accessability.
 

--- a/packages/mui/src/components/ElementAvatar/getColor.test.ts
+++ b/packages/mui/src/components/ElementAvatar/getColor.test.ts
@@ -21,6 +21,6 @@ describe('getColor', () => {
   it('should generate stable colors from ids', () => {
     expect(getColor('@oliver.sand:matrix.org')).toBe('#ac3ba8');
     expect(getColor('!OFRzoSUQYSjIXMEZDS:datanauten.de')).toBe('#368bd6');
-    expect(getColor('!vbSFpwCIcbnazhtFTT:matrix.org')).toBe('#0DBD8B');
+    expect(getColor('!vbSFpwCIcbnazhtFTT:matrix.org')).toBe('#007a61');
   });
 });

--- a/packages/mui/src/components/ElementAvatar/getColor.ts
+++ b/packages/mui/src/components/ElementAvatar/getColor.ts
@@ -17,7 +17,7 @@
 export function getColor(id: string): string {
   // Same colors and algorithm as Element is using, to get the same results:
   // https://github.com/matrix-org/matrix-react-sdk/blob/667ec166d736dfb0ac49f67398a8b7a13db7d5ef/src/Avatar.ts#L91
-  const defaultColors = ['#0DBD8B', '#368bd6', '#ac3ba8'];
+  const defaultColors = ['#007a61', '#368bd6', '#ac3ba8'];
   let total = 0;
   for (let i = 0; i < id.length; ++i) {
     total += id.charCodeAt(i);

--- a/packages/mui/src/components/MuiThemeProvider/theme.ts
+++ b/packages/mui/src/components/MuiThemeProvider/theme.ts
@@ -29,9 +29,18 @@ const fontFamily = [
   '"Noto Color Emoji"',
 ].join(',');
 
-const primaryColor = getEnvironment('REACT_APP_PRIMARY_COLOR', '#0dbd8b');
+const primaryColorlight = getEnvironment(
+  'REACT_APP_LIGHT_PRIMARY_COLOR',
+  '#007a61',
+);
+const primaryColorDark = getEnvironment(
+  'REACT_APP_DARK_PRIMARY_COLOR',
+  '#129a78',
+);
 const primaryColorHighContrast = '#075D53';
 const errorColor = '#ff5b55';
+const errorColorlight = '#d51928';
+const errorColorDark = '#fd3e3c';
 const errorColorHighContrast = '#AA0904';
 
 function createSwitchStyleOverrides({
@@ -119,7 +128,7 @@ export const baseTheme: ThemeOptions = {
   },
   palette: {
     primary: {
-      main: primaryColor,
+      main: primaryColorlight,
       contrastText: '#ffffff',
     },
     error: {
@@ -371,6 +380,12 @@ export const lightTheme: ThemeOptions = {
       default: '#ffffff',
       paper: '#f2f5f8',
     },
+    primary: {
+      main: primaryColorlight,
+    },
+    error: {
+      main: errorColorlight,
+    },
     text: {
       primary: '#17191c',
       secondary: '#61708b',
@@ -538,6 +553,12 @@ export const darkTheme: ThemeOptions = {
     background: {
       default: '#15191e',
       paper: '#20252b',
+    },
+    primary: {
+      main: primaryColorDark,
+    },
+    error: {
+      main: errorColorDark,
     },
     text: {
       primary: '#ffffff',

--- a/packages/mui/src/components/MuiThemeProvider/theme.ts
+++ b/packages/mui/src/components/MuiThemeProvider/theme.ts
@@ -38,8 +38,7 @@ const primaryColorDark = getEnvironment(
   '#129a78',
 );
 const primaryColorHighContrast = '#075D53';
-const errorColor = '#ff5b55';
-const errorColorlight = '#d51928';
+const errorColorLight = '#d51928';
 const errorColorDark = '#fd3e3c';
 const errorColorHighContrast = '#AA0904';
 
@@ -132,7 +131,7 @@ export const baseTheme: ThemeOptions = {
       contrastText: '#ffffff',
     },
     error: {
-      main: errorColor,
+      main: errorColorLight,
       contrastText: '#ffffff',
     },
     tonalOffset: 0.025,
@@ -384,7 +383,7 @@ export const lightTheme: ThemeOptions = {
       main: primaryColorlight,
     },
     error: {
-      main: errorColorlight,
+      main: errorColorLight,
     },
     text: {
       primary: '#17191c',


### PR DESCRIPTION
Align widget green and red with Element green and red to Keep the look of Element and widgets in sync.

![Screenshot_20241024_154619](https://github.com/user-attachments/assets/b97141b0-f889-44f9-8e33-d97868e5333d)

![Screenshot_20241024_154643](https://github.com/user-attachments/assets/53bf2037-1cfb-4639-bc67-5d15d066bc0d)


**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
