### PR TITLE
Move vitest to dev dependencies

### DIFF
--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -15,7 +15,8 @@
     "@types/node": "22.7.5",
     "@vitest/coverage-v8": "2.1.3",
     "typescript": "5.6.3",
-    "vite": "5.4.8"
+    "vite": "5.4.8",
+    "vitest": "2.1.3"
   },
   "scripts": {
     "build": "tsc && rollup --config ../../rollup.config.mjs",
@@ -32,8 +33,7 @@
   "dependencies": {
     "@matrix-widget-toolkit/api": "^3.4.2",
     "matrix-widget-api": "1.9.0",
-    "rxjs": "7.8.1",
-    "vitest": "2.1.3"
+    "rxjs": "7.8.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
vitest should be a dev dependency

This causes renovate to show it in the prod group like here: https://github.com/nordeck/matrix-widget-toolkit/pull/841

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
