### PR TITLE
Add ESLint rule to enforce the "widget-toolkit" translation namespace

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,6 +94,27 @@ export default ts.config(
       ],
     },
   },
+  // mui package specific rules
+  {
+    files: ['packages/mui/**'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.name='useTranslation'][arguments.0.value!='widget-toolkit']",
+          message:
+            'useTranslation() must be invoked with the "widget-toolkit" namespace arg: useTranslation("widget-toolkit")',
+        },
+        {
+          selector:
+            "JSXElement[openingElement.name.name='Trans']:not(:has(JSXAttribute[name.name='ns'][value.value!='widget-toolkit']))",
+          message:
+            '<Trans> must be used with the "widget-toolkit" "ns" prop: <Trans … ns="widget-toolkit" … >',
+        },
+      ],
+    },
+  },
   // Relax some rules for test files only
   {
     files: ['**/*.test.*'],


### PR DESCRIPTION
By that we avoid calls without namespace and translations not working in packages depending on the SDK.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
