### PR TITLE
Prevent the colorHash prop being leaked to the DOM

### DIFF
--- a/.changeset/yellow-seas-attend.md
+++ b/.changeset/yellow-seas-attend.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/mui': patch
+---
+
+Prevent leak of colorHash prop to the DOM when using an avatar

--- a/packages/mui/src/components/ElementAvatar/ElementAvatar.tsx
+++ b/packages/mui/src/components/ElementAvatar/ElementAvatar.tsx
@@ -86,7 +86,7 @@ export type ElementAvatarProps = {
 } & AvatarProps;
 
 const StyledAvatar = styled(Avatar, {
-  shouldForwardProp: (p) => p !== 'color',
+  shouldForwardProp: (p: string) => !['color', 'colorHash'].includes(p),
 })<{ colorHash: number }>(({ theme, colorHash }) => ({
   // increase the specificity of the css selector to override styles of
   // chip or button components that provide their own css for avatars.


### PR DESCRIPTION
Fixes „React does not recognize the `colorHash` prop on a DOM element.“ messages.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
