### PR TITLE
Support for optionally required widget parameters

### DIFF
--- a/.changeset/cuddly-kings-exercise.md
+++ b/.changeset/cuddly-kings-exercise.md
@@ -1,0 +1,7 @@
+---
+'@matrix-widget-toolkit/react': patch
+'@matrix-widget-toolkit/api': patch
+'@matrix-widget-toolkit/mui': patch
+---
+
+WidgetRegistration options for WidgetApiPromise can now have a requiredParameters list that will be checked upon registation.

--- a/example-widget-mui/src/App/App.tsx
+++ b/example-widget-mui/src/App/App.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { WidgetApi } from '@matrix-widget-toolkit/api';
+import { WidgetApi, WidgetParameter } from '@matrix-widget-toolkit/api';
 import {
   MuiThemeProvider,
   MuiWidgetApiProvider,
@@ -50,6 +50,8 @@ export function App({
               name: 'Example Widget',
               type: 'com.example.clock',
               data: { title: 'Learn more…' },
+              // Device ID is required for the WelcomePage example
+              requiredParameters: [WidgetParameter.DeviceId],
             }}
           >
             <Routes>

--- a/packages/api/api-report.api.md
+++ b/packages/api/api-report.api.md
@@ -66,13 +66,13 @@ export function getRoomMemberDisplayName(member: StateEvent<RoomMemberStateEvent
 export function hasActionPower(powerLevelStateEvent: PowerLevelsStateEvent | undefined, userId: string | undefined, action: PowerLevelsActions): boolean;
 
 // @public
-export function hasRequiredWidgetParameters(widgetApi: WidgetApi): boolean;
-
-// @public
 export function hasRoomEventPower(powerLevelStateEvent: PowerLevelsStateEvent | undefined, userId: string | undefined, eventType: string): boolean;
 
 // @public
 export function hasStateEventPower(powerLevelStateEvent: PowerLevelsStateEvent | undefined, userId: string | undefined, eventType: string): boolean;
+
+// @public
+export function hasWidgetParameters(widgetApi: WidgetApi): boolean;
 
 // @public
 export function isRoomEvent(event: RoomEvent | StateEvent): event is RoomEvent;
@@ -398,6 +398,28 @@ export type WidgetId = {
 };
 
 // @public
+export enum WidgetParameter {
+    // (undocumented)
+    AvatarUrl = "avatarUrl",
+    // (undocumented)
+    BaseUrl = "baseUrl",
+    // (undocumented)
+    ClientId = "clientId",
+    // (undocumented)
+    ClientLanguage = "clientLanguage",
+    // (undocumented)
+    DeviceId = "deviceId",
+    // (undocumented)
+    DisplayName = "displayName",
+    // (undocumented)
+    RoomId = "roomId",
+    // (undocumented)
+    Theme = "theme",
+    // (undocumented)
+    UserId = "userId"
+}
+
+// @public
 export type WidgetParameters = {
     userId?: string;
     displayName?: string;
@@ -415,6 +437,7 @@ export type WidgetParameters = {
 export type WidgetRegistration = {
     type?: string;
     name?: string;
+    requiredParameters?: WidgetParameter[];
     avatarUrl?: string;
     data?: Record<string, unknown> | {
         title?: string;

--- a/packages/api/src/api/index.ts
+++ b/packages/api/src/api/index.ts
@@ -24,9 +24,10 @@ export {
 export type { WidgetApiParameters, WidgetId } from './parameters';
 export {
   generateWidgetRegistrationUrl,
-  hasRequiredWidgetParameters,
+  hasWidgetParameters,
   repairWidgetRegistration,
 } from './registration';
+export { WidgetParameter } from './types';
 export type {
   RoomEvent,
   StateEvent,

--- a/packages/api/src/api/registration.test.ts
+++ b/packages/api/src/api/registration.test.ts
@@ -17,21 +17,21 @@
 import { beforeEach, describe, expect, it, Mocked, vi } from 'vitest';
 import {
   generateWidgetRegistrationUrl,
-  hasRequiredWidgetParameters,
+  hasWidgetParameters,
   repairWidgetRegistration,
   STATE_EVENT_WIDGETS,
 } from './registration';
 import { WidgetApi } from './types';
 
-describe('hasRequiredWidgetParameters', () => {
-  it('should fail if a required parameter is missing', () => {
+describe('hasWidgetParameters', () => {
+  it('should fail if a parameter is missing', () => {
     const widgetApi = {
       widgetParameters: {
         displayName: 'my-display-name',
       },
     } as Partial<WidgetApi> as WidgetApi;
 
-    expect(hasRequiredWidgetParameters(widgetApi)).toEqual(false);
+    expect(hasWidgetParameters(widgetApi)).toEqual(false);
   });
 
   it('should succeed if all required parameter are available', () => {
@@ -49,7 +49,7 @@ describe('hasRequiredWidgetParameters', () => {
       },
     } as Partial<WidgetApi> as WidgetApi;
 
-    expect(hasRequiredWidgetParameters(widgetApi)).toEqual(true);
+    expect(hasWidgetParameters(widgetApi)).toEqual(true);
   });
 
   it('should succeed, even if a parameter is just an empty string', () => {
@@ -67,7 +67,7 @@ describe('hasRequiredWidgetParameters', () => {
       },
     } as Partial<WidgetApi> as WidgetApi;
 
-    expect(hasRequiredWidgetParameters(widgetApi)).toEqual(true);
+    expect(hasWidgetParameters(widgetApi)).toEqual(true);
   });
 });
 

--- a/packages/api/src/api/registration.ts
+++ b/packages/api/src/api/registration.ts
@@ -23,12 +23,12 @@ import { extractRawWidgetParameters } from './parameters';
 import { WidgetApi, WidgetParameters, WidgetRegistration } from './types';
 
 /**
- * Checks whether all widget parameters were provided to the widget.
+ * Checks whether the necessary widget parameters were provided to the widget.
  *
  * @param widgetApi - The widget api to read the parameters from
  * @returns True, if all parameters were provided.
  */
-export function hasRequiredWidgetParameters(widgetApi: WidgetApi): boolean {
+export function hasWidgetParameters(widgetApi: WidgetApi): boolean {
   return (
     typeof widgetApi.widgetParameters.userId === 'string' &&
     typeof widgetApi.widgetParameters.displayName === 'string' &&
@@ -37,7 +37,6 @@ export function hasRequiredWidgetParameters(widgetApi: WidgetApi): boolean {
     typeof widgetApi.widgetParameters.theme === 'string' &&
     typeof widgetApi.widgetParameters.clientId === 'string' &&
     typeof widgetApi.widgetParameters.clientLanguage === 'string' &&
-    typeof widgetApi.widgetParameters.deviceId === 'string' &&
     typeof widgetApi.widgetParameters.baseUrl === 'string'
   );
 }

--- a/packages/api/src/api/types.ts
+++ b/packages/api/src/api/types.ts
@@ -35,6 +35,21 @@ import {
 import { Observable } from 'rxjs';
 
 /**
+ * Enumeration of widget parameters that can be checked if they are available upon registration.
+ */
+export enum WidgetParameter {
+  UserId = 'userId',
+  DisplayName = 'displayName',
+  AvatarUrl = 'avatarUrl',
+  RoomId = 'roomId',
+  Theme = 'theme',
+  ClientId = 'clientId',
+  ClientLanguage = 'clientLanguage',
+  DeviceId = 'deviceId',
+  BaseUrl = 'baseUrl',
+}
+
+/**
  * Parameters passed from the client to the widget during initialization.
  */
 export type WidgetParameters = {
@@ -158,6 +173,12 @@ export type WidgetRegistration = {
    * The display name of the widget.
    */
   name?: string;
+  /**
+   * Checks for custom widget-specific registration parameters that might be required.
+   *
+   * Added for backwards compatibility with old widget registrations.
+   */
+  requiredParameters?: WidgetParameter[];
   /**
    * The avatar URL used to display an icon on the widget.
    *

--- a/packages/mui/src/components/MuiWidgetApiProvider/MuiWidgetApiProvider.test.tsx
+++ b/packages/mui/src/components/MuiWidgetApiProvider/MuiWidgetApiProvider.test.tsx
@@ -16,7 +16,7 @@
 
 import {
   extractWidgetParameters as extractWidgetParametersMocked,
-  hasRequiredWidgetParameters as hasRequiredWidgetParametersMocked,
+  hasWidgetParameters as hasWidgetParametersMocked,
   WidgetApi,
 } from '@matrix-widget-toolkit/api';
 import { render, screen } from '@testing-library/react';
@@ -25,9 +25,7 @@ import { MuiWidgetApiProvider } from './MuiWidgetApiProvider';
 
 vi.mock('@matrix-widget-toolkit/api');
 
-const hasRequiredWidgetParameters = vi.mocked(
-  hasRequiredWidgetParametersMocked,
-);
+const hasWidgetParameters = vi.mocked(hasWidgetParametersMocked);
 
 const extractWidgetParameters = vi.mocked(extractWidgetParametersMocked);
 
@@ -50,7 +48,7 @@ describe('WidgetApiProvider', () => {
   });
 
   it('should render without exploding', async () => {
-    hasRequiredWidgetParameters.mockReturnValue(true);
+    hasWidgetParameters.mockReturnValue(true);
     widgetApi.hasInitialCapabilities.mockReturnValue(true);
 
     render(

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -17,6 +17,47 @@ yarn add @matrix-widget-toolkit/react
 While this package contains a `<WidgetApiProvider>` you probably don't want to use this package most of the time.
 Prefer using [`@matrix-widget-toolkit/mui`](../mui/) which internally uses this package to share functionality.
 
+### Customizing Widget Registration
+
+You can customise the Widget registration with a name and type. This will be used to show the widget name in the
+`Extensions` page of Element Web:
+
+```typescript
+<WidgetApiProvider
+  widgetApiPromise={widgetApiPromise}
+  widgetRegistration={{
+    name: 'Example Widget',
+    type: 'com.example.clock',
+    data: { title: 'Learn more…' },
+  }}
+>
+```
+
+### Checking for specific Widget Parameters
+
+Widgets must be registered within the room state with a set of parameters that the hosting client will provide,
+such as the `matrix_user_id`, `matrix_room_id` and others that are essential for the Widget to operate under
+the correct context.
+
+As new parameters have been introduced and exposed in the Widget API and hosting clients, by default they will
+not be checked during registration and might not be available for the widget to use.
+
+To check for specific parameters and require a re-registration of the widget if they are absent, you can create
+the provider component with a list of required `WidgetParameter`'s:
+
+```typescript
+<WidgetApiProvider
+  widgetApiPromise={widgetApiPromise}
+  widgetRegistration={{
+    name: 'Example Widget',
+    type: 'com.example.clock',
+    data: { title: 'Learn more…' },
+    // Device ID must be available upon registration
+    requiredParameters: [WidgetParameter.DeviceId],
+  }}
+>
+```
+
 ### Acessing the Widget API
 
 Once the Widget API is provided to React components, use the `useWidgetApi` hook to access it:

--- a/packages/react/src/components/WidgetApiProvider/WidgetApiProvider.tsx
+++ b/packages/react/src/components/WidgetApiProvider/WidgetApiProvider.tsx
@@ -16,8 +16,9 @@
 
 import {
   extractWidgetParameters,
-  hasRequiredWidgetParameters,
+  hasWidgetParameters,
   WidgetApi,
+  WidgetParameter,
   WidgetRegistration,
 } from '@matrix-widget-toolkit/api';
 import {
@@ -143,7 +144,23 @@ export function WidgetApiProvider({
     );
   }
 
-  const hasParameters = hasRequiredWidgetParameters(widgetApi);
+  let hasParameters = hasWidgetParameters(widgetApi);
+
+  // Check for custom required parameters that are not part of the default setup
+  // and fail registration if they are missing.
+  const customRequiredParameters = widgetRegistration?.requiredParameters ?? [];
+  const parametersDict = widgetApi.widgetParameters as Record<
+    WidgetParameter,
+    unknown
+  >;
+
+  if (customRequiredParameters.length > 0) {
+    hasParameters =
+      hasParameters &&
+      customRequiredParameters.every((param: WidgetParameter) => {
+        return (typeof parametersDict[param] as string) === 'string';
+      });
+  }
 
   return (
     <WidgetApiContext.Provider value={widgetApi}>

--- a/packages/react/src/components/WidgetApiProvider/WidgetApiProvider.tsx
+++ b/packages/react/src/components/WidgetApiProvider/WidgetApiProvider.tsx
@@ -149,16 +149,15 @@ export function WidgetApiProvider({
   // Check for custom required parameters that are not part of the default setup
   // and fail registration if they are missing.
   const customRequiredParameters = widgetRegistration?.requiredParameters ?? [];
-  const parametersDict = widgetApi.widgetParameters as Record<
-    WidgetParameter,
-    unknown
-  >;
 
   if (customRequiredParameters.length > 0) {
     hasParameters =
       hasParameters &&
       customRequiredParameters.every((param: WidgetParameter) => {
-        return (typeof parametersDict[param] as string) === 'string';
+        return (
+          param in widgetApi.widgetParameters &&
+          (typeof widgetApi.widgetParameters[param] as string) === 'string'
+        );
       });
   }
 


### PR DESCRIPTION
When introducing the Device ID widget parameter, all already registered widgets would fail to load, requiring a manual re-registration by a room member with enough permissions.

This PR removes device id from the required parameters for widget registration and adds a way for the `WidgetApiProvider` component to specify which, if any, parameters it must require, such as the device id, thus maintaining backwards compatibility for widgets that do not require it.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [X] Added or updated documentation.
- [X] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
