### PR TITLE
Disable the update_state API to resolve issues with reading room state

### DIFF
--- a/.changeset/hot-trains-drop.md
+++ b/.changeset/hot-trains-drop.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/api': patch
+---
+
+Disable the update_state API to resolve issues with reading room state.


### PR DESCRIPTION
Disables the `update_state` API that is not currently supported to be able to read room state.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [ ] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
