### PR TITLE
Fixed typo in mobile client error text

### DIFF
--- a/.changeset/cool-carrots-fetch.md
+++ b/.changeset/cool-carrots-fetch.md
@@ -1,0 +1,5 @@
+---
+'@matrix-widget-toolkit/mui': patch
+---
+
+Fix typo in mobile-client instructions

--- a/packages/mui/src/components/MuiWidgetApiProvider/MobileClientError.tsx
+++ b/packages/mui/src/components/MuiWidgetApiProvider/MobileClientError.tsx
@@ -31,7 +31,7 @@ export function MobileClientError(): ReactElement {
 
         {t(
           'mobile-client.instructions',
-          "The widget doesn't work in mobile clients due to technical limitations. Open the widget on you Desktop or Web client.",
+          "The widget doesn't work in mobile clients due to technical limitations. Open the widget on your Desktop or Web client.",
         )}
       </Alert>
     </Box>

--- a/packages/mui/src/locales/en/widget-toolkit.json
+++ b/packages/mui/src/locales/en/widget-toolkit.json
@@ -30,7 +30,7 @@
     "title": "Wrong widget registration"
   },
   "mobile-client": {
-    "instructions": "The widget doesn't work in mobile clients due to technical limitations. Open the widget on you Desktop or Web client.",
+    "instructions": "The widget doesn't work in mobile clients due to technical limitations. Open the widget on your Desktop or Web client.",
     "title": "Mobile clients are not supported"
   },
   "outside-client": {


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

Just noticed this small typo when I was working w/ the example widget. 
Changes "on you Desktop or Web client" to "on your Desktop or Web client"

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
