### PR TITLE
Let Renovate automerge digest and pinDigest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,7 +30,7 @@
   lockFileMaintenance: {
     enabled: true,
   },
-  // there is not preset for this
+  // there is no preset for this
   pinDigest: {
     automerge: true,
   },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,8 @@
     'config:recommended',
     // https://docs.renovatebot.com/presets-default/#automergepatch - Automerge lockfile maintenance, path, pin and separate minor and patch
     ':automergePatch',
+    // this is missing from the automergePatch preset
+    ':automergeDigest',
     // Pin docker
     'docker:pinDigests',
     // Pin Github Actions
@@ -27,6 +29,10 @@
   // https://docs.renovatebot.com/configuration-options/#lockfilemaintenance - Ensure the lockfile is maintained properly
   lockFileMaintenance: {
     enabled: true,
+  },
+  // there is not preset for this
+  pinDigest: {
+    automerge: true,
   },
   // https://docs.renovatebot.com/presets-schedule/#scheduleweekly - Run renovate on early mondays instead of running it too often
   // Clock giver is: https://docs.renovatebot.com/mend-hosted/overview/#resources-and-scheduling


### PR DESCRIPTION
We overlooked some automerge config, causing PRs such as https://github.com/nordeck/matrix-widget-toolkit/pull/956.