### PR TITLE
Update Renovate lockFileMaintenance schedule and labels

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,11 @@
     'schedule:automergeWeekdays',
   ],
   dependencyDashboard: true,
-  // https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts - we use osv.dev here to not rely on Github
+  // https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts - enabled by default, but does not set a label by default
+  vulnerabilityAlerts: {
+    labels: ['Security'],
+  },
+  // https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts - we use osv.dev here to not rely entirely on Github
   osvVulnerabilityAlerts: true,
   // https://docs.renovatebot.com/configuration-options/#automergetype - We use branch to not get raced by commits to main
   automergeType: 'branch',
@@ -66,7 +70,7 @@
     {
       groupName: 'lockFileMaintenance updates',
       matchUpdateTypes: ['lockFileMaintenance'],
-      addLabels: ['lockFileMaintenance'],
+      addLabels: ['Lockfile'],
     },
     {
       groupName: 'development-dependencies',
@@ -118,7 +122,7 @@
         'prettier-*',
         '@typescript-eslint/*',
       ],
-      addLabels: ['Linting'],
+      addLabels: ['Linters'],
     },
     {
       groupName: 'mui dependencies',
@@ -143,7 +147,7 @@
     {
       groupName: 'matrix-widget-toolkit monorepo',
       matchPackageNames: ['@matrix-widget-toolkit/*'],
-      addLabels: ['Matrix-Widget-Toolkit'],
+      addLabels: ['matrix-widget-toolkit'],
     },
   ],
 }


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#lockfilemaintenance

For some reason the lockFileMaintenance default schedule overrides the global schedule, so we have to sync them manually.