### PR TITLE
Make renovate group pins

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -149,5 +149,10 @@
       matchPackageNames: ['@matrix-widget-toolkit/*'],
       addLabels: ['matrix-widget-toolkit'],
     },
+    // override for pins in the end so they're all nicely grouped
+    {
+      groupName: 'pin dependencies',
+      matchUpdateTypes: ['pin', 'pinDigest'],
+    },
   ],
 }


### PR DESCRIPTION
Before:
<img width="811" height="1071" alt="image" src="https://github.com/user-attachments/assets/8fd1f0af-cd17-479e-bdad-f5b5e37d5dd8" />
After:
<img width="478" height="970" alt="image" src="https://github.com/user-attachments/assets/d7dec870-054a-417c-9b42-9b086136c8a3" />
(disclaimer: "After" also is 2 weeks later worth of updates)