### PR TITLE
Add support for sticky events

### DIFF
--- a/.changeset/cute-words-cut.md
+++ b/.changeset/cute-words-cut.md
@@ -1,0 +1,6 @@
+---
+'@matrix-widget-toolkit/testing': minor
+'@matrix-widget-toolkit/api': minor
+---
+
+Add support for sticky events

--- a/.changeset/cute-words-cut.md
+++ b/.changeset/cute-words-cut.md
@@ -3,4 +3,4 @@
 '@matrix-widget-toolkit/api': minor
 ---
 
-Add support for sticky events
+Add support for sticky events (MSC4407)

--- a/example-widget-mui/src/DicePage/DicePage.test.tsx
+++ b/example-widget-mui/src/DicePage/DicePage.test.tsx
@@ -140,6 +140,34 @@ describe('<DicePage />', () => {
       {
         pips: expect.any(Number),
       },
+      undefined,
+    );
+  });
+
+  it('should throw a dice sticky', async () => {
+    render(<DicePage />, { wrapper });
+
+    await userEvent.click(
+      await screen.findByRole('checkbox', {
+        name: 'Send as sticky event',
+      }),
+    );
+
+    const button = await screen.findByRole('button', { name: /throw dice$/i });
+    await userEvent.click(button);
+
+    await expect(
+      screen.findByText(/your last throw: ./i),
+    ).resolves.toBeInTheDocument();
+
+    expect(widgetApi.sendRoomEvent).toHaveBeenCalledWith(
+      'net.nordeck.throw_dice',
+      {
+        pips: expect.any(Number),
+      },
+      {
+        stickyDurationMs: 1000,
+      },
     );
   });
 
@@ -167,6 +195,43 @@ describe('<DicePage />', () => {
         pips: expect.any(Number),
       },
       expect.any(Number),
+      undefined,
+    );
+  });
+
+  it('should throw a dice delayed and sticky', async () => {
+    render(<DicePage />, { wrapper });
+
+    await userEvent.click(
+      await screen.findByRole('checkbox', {
+        name: 'Send as sticky event',
+      }),
+    );
+
+    const button = await screen.findByRole('button', {
+      name: /throw dice 10 seconds delayed/i,
+    });
+    await userEvent.click(button);
+
+    await expect(
+      screen.findByText(/your last throw: ./i),
+    ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(/your last delay id: ./i),
+    ).resolves.toBeInTheDocument();
+    await expect(
+      screen.findByText(/throw dice delayed event actions:/i),
+    ).resolves.toBeInTheDocument();
+
+    expect(widgetApi.sendDelayedRoomEvent).toHaveBeenCalledWith(
+      'net.nordeck.throw_dice',
+      {
+        pips: expect.any(Number),
+      },
+      expect.any(Number),
+      {
+        stickyDurationMs: 1000,
+      },
     );
   });
 
@@ -193,6 +258,7 @@ describe('<DicePage />', () => {
           pips: expect.any(Number),
         },
         expect.any(Number),
+        undefined,
       );
 
       const updateButton = await screen.findByRole('button', {
@@ -230,6 +296,7 @@ describe('<DicePage />', () => {
         pips: expect.any(Number),
       },
       expect.any(Number),
+      undefined,
     );
 
     const updateButton = await screen.findByRole('button', {

--- a/example-widget-mui/src/DicePage/DicePage.tsx
+++ b/example-widget-mui/src/DicePage/DicePage.tsx
@@ -24,9 +24,13 @@ import {
   ButtonGroup,
   Card,
   CardContent,
+  FormControl,
+  FormControlLabel,
+  Switch,
   Typography,
 } from '@mui/material';
 import {
+  Capability,
   EventDirection,
   MatrixCapabilities,
   UpdateDelayedEventAction,
@@ -71,10 +75,11 @@ const eventDelayMs = 10000;
 
 export const DiceView = (): ReactElement => {
   const widgetApi = useWidgetApi();
+  const [sendAsStickyEvent, setSendAsStickyEvent] = useState<boolean>(false);
   const [lastOwnDice, setLastOwnDice] = useState<number | undefined>();
   const [lastDelayId, setLastDelayId] = useState<string | undefined>();
   const [lastDelayIdExpired, setLastDelayIdExpired] = useState<boolean>(false);
-  const [lastDelayError, setLastDelayError] = useState<string | undefined>();
+  const [lastError, setLastError] = useState<string | undefined>();
   const [dices, setDices] = useState<number[]>([]);
 
   const lastDelayIdTimeoutRef = useRef<Timeout>();
@@ -104,29 +109,49 @@ export const DiceView = (): ReactElement => {
   }, []);
 
   async function handleThrowDice() {
-    await widgetApi.requestCapabilities([
+    const capabilities: (WidgetEventCapability | Capability)[] = [
       WidgetEventCapability.forRoomEvent(
         EventDirection.Send,
         STATE_EVENT_THROW_DICE,
       ),
-    ]);
+    ];
+    if (sendAsStickyEvent) {
+      capabilities.push(MatrixCapabilities.MSC4407SendStickyEvent);
+    }
+    await widgetApi.requestCapabilities(capabilities);
 
     const pips = Math.floor(Math.random() * 6) + 1;
-    const result = await widgetApi.sendRoomEvent<ThrowDiceEvent>(
-      STATE_EVENT_THROW_DICE,
-      { pips },
-    );
-    setLastOwnDice(result.content.pips);
+    try {
+      const result = await widgetApi.sendRoomEvent<ThrowDiceEvent>(
+        STATE_EVENT_THROW_DICE,
+        { pips },
+        sendAsStickyEvent
+          ? {
+              stickyDurationMs: 1000,
+            }
+          : undefined,
+      );
+      setLastOwnDice(result.content.pips);
+      setLastError(undefined);
+    } catch (e) {
+      if (isError(e)) {
+        setLastError(e.message);
+      }
+    }
   }
 
   async function handleThrowDiceDelayed() {
-    await widgetApi.requestCapabilities([
+    const capabilities: (WidgetEventCapability | Capability)[] = [
       MatrixCapabilities.MSC4157SendDelayedEvent,
       WidgetEventCapability.forRoomEvent(
         EventDirection.Send,
         STATE_EVENT_THROW_DICE,
       ),
-    ]);
+    ];
+    if (sendAsStickyEvent) {
+      capabilities.push(MatrixCapabilities.MSC4407SendStickyEvent);
+    }
+    await widgetApi.requestCapabilities(capabilities);
 
     const pips = Math.floor(Math.random() * 6) + 1;
     try {
@@ -134,20 +159,25 @@ export const DiceView = (): ReactElement => {
         STATE_EVENT_THROW_DICE,
         { pips },
         eventDelayMs,
+        sendAsStickyEvent
+          ? {
+              stickyDurationMs: 1000,
+            }
+          : undefined,
       );
       setLastOwnDice(pips);
       setLastDelayId(delay_id);
       setLastDelayIdExpired(false);
-      setLastDelayError(undefined);
+      setLastError(undefined);
 
       clearTimeout(lastDelayIdTimeoutRef.current);
       lastDelayIdTimeoutRef.current = setTimeout(() => {
         setLastDelayIdExpired(true);
       }, eventDelayMs);
-    } catch {
-      setLastDelayError(
-        'Could not send a delayed event. Please check if homeserver supports delayed events.',
-      );
+    } catch (e) {
+      if (isError(e)) {
+        setLastError(e.message);
+      }
     }
   }
 
@@ -172,9 +202,9 @@ export const DiceView = (): ReactElement => {
       } else {
         setLastDelayIdExpired(true);
       }
-      setLastDelayError(undefined);
+      setLastError(undefined);
     } catch (e) {
-      setLastDelayError(isError(e) ? e.message : JSON.stringify(e));
+      setLastError(isError(e) ? e.message : JSON.stringify(e));
     }
   }
 
@@ -193,6 +223,23 @@ export const DiceView = (): ReactElement => {
           </Typography>
         </CardContent>
       </Card>
+
+      <Box mt={2}>
+        <FormControl>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={sendAsStickyEvent}
+                onChange={(_event, checked) => {
+                  setSendAsStickyEvent(checked);
+                }}
+                sx={{ ml: 2, mr: 1 }}
+              />
+            }
+            label="Send as sticky event"
+          />
+        </FormControl>
+      </Box>
 
       <Button
         sx={{ mt: 2 }}
@@ -218,10 +265,10 @@ export const DiceView = (): ReactElement => {
         </Alert>
       )}
 
-      {lastDelayError && (
+      {lastError && (
         <Alert severity="error" sx={{ mt: 2 }}>
           <AlertTitle>Error</AlertTitle>
-          {lastDelayError}
+          {lastError}
         </Alert>
       )}
 

--- a/packages/api/api-report.api.md
+++ b/packages/api/api-report.api.md
@@ -83,6 +83,9 @@ export function hasWidgetParameters(widgetApi: WidgetApi): boolean;
 export function isRoomEvent(event: RoomEvent | StateEvent): event is RoomEvent;
 
 // @public
+export function isRoomEventCurrentlySticky(event: RoomEvent): boolean;
+
+// @public
 export function isStateEvent(event: RoomEvent | StateEvent): event is StateEvent;
 
 // @public
@@ -181,7 +184,7 @@ export const ROOM_EVENT_REDACTION = "m.room.redaction";
 export const ROOM_VERSION_12_CREATOR = "ROOM_VERSION_12_CREATOR";
 
 // @public
-export type RoomEvent<T = unknown> = Omit<IRoomEvent, 'content' | 'state_key' | 'unsigned'> & {
+export type RoomEvent<T = unknown> = Omit<IRoomEvent, 'content' | 'state_key' | 'unsigned' | 'sticky'> & {
     content: T;
 };
 
@@ -208,7 +211,7 @@ export const STATE_EVENT_POWER_LEVELS = "m.room.power_levels";
 export const STATE_EVENT_ROOM_MEMBER = "m.room.member";
 
 // @public
-export type StateEvent<T = unknown> = Omit<IRoomEvent, 'content' | 'unsigned' | 'state_key'> & {
+export type StateEvent<T = unknown> = Omit<IRoomEvent, 'content' | 'unsigned' | 'state_key' | 'sticky'> & {
     state_key: string;
     content: T;
 };
@@ -280,9 +283,11 @@ export type WidgetApi = {
     }): Observable<RoomEvent<T>>;
     sendRoomEvent<T>(eventType: string, content: T, options?: {
         roomId?: string;
+        stickyDurationMs?: number;
     }): Promise<RoomEvent<T>>;
     sendDelayedRoomEvent<T>(eventType: string, content: T, delay: number, options?: {
         roomId?: string;
+        stickyDurationMs?: number;
     }): Promise<{
         delay_id: string;
     }>;
@@ -395,6 +400,7 @@ export class WidgetApiImpl implements WidgetApi {
     }>;
     sendDelayedRoomEvent<T>(eventType: string, content: T, delay: number, input?: {
         roomId?: string;
+        stickyDurationMs?: number;
     }): Promise<{
         delay_id: string;
     }>;
@@ -406,6 +412,7 @@ export class WidgetApiImpl implements WidgetApi {
     }>;
     sendRoomEvent<T>(eventType: string, content: T, input?: {
         roomId?: string;
+        stickyDurationMs?: number;
     }): Promise<RoomEvent<T>>;
     sendStateEvent<T>(eventType: string, content: T, input?: {
         roomId?: string;

--- a/packages/api/api-report.api.md
+++ b/packages/api/api-report.api.md
@@ -184,7 +184,7 @@ export const ROOM_EVENT_REDACTION = "m.room.redaction";
 export const ROOM_VERSION_12_CREATOR = "ROOM_VERSION_12_CREATOR";
 
 // @public
-export type RoomEvent<T = unknown> = Omit<IRoomEvent, 'content' | 'state_key' | 'unsigned' | 'sticky'> & {
+export type RoomEvent<T = unknown> = Omit<IRoomEvent, 'content' | 'state_key' | 'unsigned'> & {
     content: T;
 };
 
@@ -211,7 +211,7 @@ export const STATE_EVENT_POWER_LEVELS = "m.room.power_levels";
 export const STATE_EVENT_ROOM_MEMBER = "m.room.member";
 
 // @public
-export type StateEvent<T = unknown> = Omit<IRoomEvent, 'content' | 'unsigned' | 'state_key' | 'sticky'> & {
+export type StateEvent<T = unknown> = Omit<IRoomEvent, 'content' | 'unsigned' | 'state_key' | 'sticky' | 'msc4354_sticky'> & {
     state_key: string;
     content: T;
 };

--- a/packages/api/src/api/WidgetApiImpl.ts
+++ b/packages/api/src/api/WidgetApiImpl.ts
@@ -550,7 +550,10 @@ export class WidgetApiImpl implements WidgetApi {
   async sendRoomEvent<T>(
     eventType: string,
     content: T,
-    { roomId }: { roomId?: string } = {},
+    {
+      roomId,
+      stickyDurationMs,
+    }: { roomId?: string; stickyDurationMs?: number } = {},
   ): Promise<RoomEvent<T>> {
     const subject = new ReplaySubject<CustomEvent<IWidgetApiRequest>>();
     const subscription = this.events$.subscribe((e) => subject.next(e));
@@ -560,6 +563,8 @@ export class WidgetApiImpl implements WidgetApi {
         eventType,
         content,
         roomId,
+        undefined,
+        stickyDurationMs,
       );
       // TODO: Why do we even return the event, not just the event id, we never
       // need it.
@@ -587,13 +592,17 @@ export class WidgetApiImpl implements WidgetApi {
     eventType: string,
     content: T,
     delay: number,
-    { roomId }: { roomId?: string } = {},
+    {
+      roomId,
+      stickyDurationMs,
+    }: { roomId?: string; stickyDurationMs?: number } = {},
   ): Promise<{ delay_id: string }> {
     const { delay_id } = await this.matrixWidgetApi.sendRoomEvent(
       eventType,
       content,
       roomId,
       delay,
+      stickyDurationMs,
     );
 
     if (!delay_id) {

--- a/packages/api/src/api/extras/events.test.ts
+++ b/packages/api/src/api/extras/events.test.ts
@@ -486,6 +486,18 @@ describe('isRoomEventCurrentlySticky', () => {
     ).toBe(true);
   });
 
+  it('should return true if sticky room event is currently sticky using stable name', () => {
+    expect(
+      isRoomEventCurrentlySticky({
+        ...roomEventData,
+        origin_server_ts: Date.now(),
+        sticky: {
+          duration_ms: 3600000,
+        },
+      }),
+    ).toBe(true);
+  });
+
   it('should return false if sticky room event is currently not sticky', () => {
     vi.setSystemTime(3600000);
     expect(

--- a/packages/api/src/api/extras/events.test.ts
+++ b/packages/api/src/api/extras/events.test.ts
@@ -18,6 +18,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RoomEvent, StateEvent, ToDeviceMessageEvent } from '../types';
 import {
   isRoomEvent,
+  isRoomEventCurrentlySticky,
   isStateEvent,
   isValidCreateEventSchema,
   isValidPowerLevelStateEvent,
@@ -87,6 +88,17 @@ describe('isValidRoomEvent', () => {
     expect(isValidRoomEvent(roomEventData)).toBe(true);
   });
 
+  it('should accept sticky event', () => {
+    expect(
+      isValidRoomEvent({
+        ...roomEventData,
+        msc4354_sticky: {
+          duration_ms: 3600000,
+        },
+      }),
+    ).toBe(true);
+  });
+
   it.each<object>([
     { type: undefined },
     { sender: undefined },
@@ -98,6 +110,14 @@ describe('isValidRoomEvent', () => {
     { event_id: 23 },
     { origin_server_ts: 'string' },
     { content: 23 },
+    {
+      msc4354_sticky: {},
+    },
+    {
+      msc4354_sticky: {
+        duration_ms: 'string',
+      },
+    },
   ])('should reject room event with patch %p', (patch: object) => {
     expect(
       isValidRoomEvent({
@@ -446,5 +466,53 @@ describe('isValidCreateEventSchema', () => {
     };
 
     expect(isValidCreateEventSchema(event)).toEqual(false);
+  });
+});
+
+describe('isRoomEventCurrentlySticky', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return true if sticky room event is currently sticky', () => {
+    expect(
+      isRoomEventCurrentlySticky({
+        ...roomEventData,
+        origin_server_ts: Date.now(),
+        msc4354_sticky: {
+          duration_ms: 3600000,
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('should return false if sticky room event is currently not sticky', () => {
+    vi.setSystemTime(3600000);
+    expect(
+      isRoomEventCurrentlySticky({
+        ...roomEventData,
+        origin_server_ts: 0,
+        msc4354_sticky: {
+          duration_ms: 3600000,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false if sticky room event is currently not sticky, duration_ms is greater 3600000', () => {
+    vi.setSystemTime(3600000);
+    expect(
+      isRoomEventCurrentlySticky({
+        ...roomEventData,
+        origin_server_ts: 0,
+        msc4354_sticky: {
+          duration_ms: 3600001,
+        },
+      }),
+    ).toBe(false);
+  });
+
+  it('should return false if event is not a sticky event', () => {
+    expect(isRoomEventCurrentlySticky(roomEventData)).toBe(false);
   });
 });

--- a/packages/api/src/api/extras/events.ts
+++ b/packages/api/src/api/extras/events.ts
@@ -110,13 +110,19 @@ export function isValidToDeviceMessageEvent(
  * @returns true if event is a sticky event and is not expired according to sticky duration, otherwise false
  */
 export function isRoomEventCurrentlySticky(event: RoomEvent): boolean {
-  if (!event.msc4354_sticky) {
+  let eventSticky: {
+    duration_ms: number;
+  };
+  if (event.sticky) {
+    eventSticky = event.sticky;
+  } else if (event.msc4354_sticky) {
+    eventSticky = event.msc4354_sticky;
+  } else {
     return false;
   }
   const now = Date.now();
   const startTime = Math.min(event.origin_server_ts, now);
-  const endTime =
-    startTime + Math.min(event.msc4354_sticky.duration_ms, 3600000);
+  const endTime = startTime + Math.min(eventSticky.duration_ms, 3600000);
   return endTime > now;
 }
 

--- a/packages/api/src/api/extras/events.ts
+++ b/packages/api/src/api/extras/events.ts
@@ -104,6 +104,22 @@ export function isValidToDeviceMessageEvent(
   return true;
 }
 
+/**
+ * Check if the given event is a sticky event and is not expired according to sticky duration.
+ * @param event - The room event to check
+ * @returns true if event is a sticky event and is not expired according to sticky duration, otherwise false
+ */
+export function isRoomEventCurrentlySticky(event: RoomEvent): boolean {
+  if (!event.msc4354_sticky) {
+    return false;
+  }
+  const now = Date.now();
+  const startTime = Math.min(event.origin_server_ts, now);
+  const endTime =
+    startTime + Math.min(event.msc4354_sticky.duration_ms, 3600000);
+  return endTime > now;
+}
+
 const eventSchemaBasicProps = {
   // Do roughly check against the format
   // https://spec.matrix.org/v1.13/appendices/#common-identifier-format
@@ -125,6 +141,9 @@ export const roomEventSchema = Joi.object<RoomEvent>({
   ...eventSchemaProps,
   event_id: Joi.string().pattern(new RegExp('^\\$.*')).required(),
   origin_server_ts: Joi.date().timestamp('javascript').required(),
+  msc4354_sticky: Joi.object({
+    duration_ms: Joi.number().required(),
+  }).unknown(),
 }).unknown();
 
 export const stateEventSchema = Joi.object<StateEvent>({

--- a/packages/api/src/api/extras/index.ts
+++ b/packages/api/src/api/extras/index.ts
@@ -19,6 +19,7 @@ export { getRoomMemberDisplayName } from './displayName';
 export {
   STATE_EVENT_CREATE,
   isRoomEvent,
+  isRoomEventCurrentlySticky,
   isStateEvent,
   isValidCreateEventSchema,
   isValidRoomEvent,

--- a/packages/api/src/api/types.ts
+++ b/packages/api/src/api/types.ts
@@ -113,7 +113,7 @@ export type WidgetParameters = {
  */
 export type StateEvent<T = unknown> = Omit<
   IRoomEvent,
-  'content' | 'unsigned' | 'state_key' | 'sticky'
+  'content' | 'unsigned' | 'state_key' | 'sticky' | 'msc4354_sticky'
 > & {
   state_key: string;
   content: T;
@@ -124,7 +124,7 @@ export type StateEvent<T = unknown> = Omit<
  */
 export type RoomEvent<T = unknown> = Omit<
   IRoomEvent,
-  'content' | 'state_key' | 'unsigned' | 'sticky'
+  'content' | 'state_key' | 'unsigned'
 > & {
   content: T;
 };

--- a/packages/api/src/api/types.ts
+++ b/packages/api/src/api/types.ts
@@ -113,7 +113,7 @@ export type WidgetParameters = {
  */
 export type StateEvent<T = unknown> = Omit<
   IRoomEvent,
-  'content' | 'unsigned' | 'state_key'
+  'content' | 'unsigned' | 'state_key' | 'sticky'
 > & {
   state_key: string;
   content: T;
@@ -124,7 +124,7 @@ export type StateEvent<T = unknown> = Omit<
  */
 export type RoomEvent<T = unknown> = Omit<
   IRoomEvent,
-  'content' | 'state_key' | 'unsigned'
+  'content' | 'state_key' | 'unsigned' | 'sticky'
 > & {
   content: T;
 };
@@ -407,11 +407,12 @@ export type WidgetApi = {
    * @param content - The content of the event.
    * @param options - Options for sending the room event.
    *                  Use `roomId` to send the room event to another room.
+   *                  Use `stickyDurationMs` to send a sticky room event.
    */
   sendRoomEvent<T>(
     eventType: string,
     content: T,
-    options?: { roomId?: string },
+    options?: { roomId?: string; stickyDurationMs?: number },
   ): Promise<RoomEvent<T>>;
 
   /**
@@ -419,17 +420,16 @@ export type WidgetApi = {
    * @param eventType - The type of the event to send.
    * @param content - The content of the event.
    * @param delay - The delay of the event in milliseconds.
-   * @param options - Options for sending the state event.
+   * @param options - Options for sending the room event.
    *                  Use `roomId` to send the state event to another room.
-   *                  Use `stateKey` to send a state event with a custom state
-   *                  key.
+   *                  Use `stickyDurationMs` to send a sticky room event.
    * @returns The result data of delayed event with delay_id.
    */
   sendDelayedRoomEvent<T>(
     eventType: string,
     content: T,
     delay: number,
-    options?: { roomId?: string },
+    options?: { roomId?: string; stickyDurationMs?: number },
   ): Promise<{ delay_id: string }>;
 
   /**

--- a/packages/testing/src/api/mockWidgetApi.test.ts
+++ b/packages/testing/src/api/mockWidgetApi.test.ts
@@ -129,6 +129,39 @@ describe('sendRoomEvent', () => {
     ).resolves.toEqual([expectedEvent]);
   });
 
+  it('should send sticky event to current room', async () => {
+    widgetApi.clearRoomEvents();
+
+    const expectedEvent = {
+      content: {
+        key: 'value',
+      },
+      event_id: expect.any(String),
+      origin_server_ts: expect.any(Number),
+      room_id: '!room-id:example.com',
+      sender: '@user-id:example.com',
+      type: 'com.example.test3',
+      msc4354_sticky: {
+        duration_ms: 3600000,
+      },
+    };
+
+    await expect(
+      widgetApi.sendRoomEvent(
+        'com.example.test3',
+        {
+          key: 'value',
+        },
+        {
+          stickyDurationMs: 3600000,
+        },
+      ),
+    ).resolves.toEqual(expectedEvent);
+    await expect(
+      widgetApi.receiveRoomEvents('com.example.test3'),
+    ).resolves.toEqual([expectedEvent]);
+  });
+
   it('should send redaction event to the current room', async () => {
     widgetApi.clearRoomEvents();
 

--- a/packages/testing/src/api/mockWidgetApi.ts
+++ b/packages/testing/src/api/mockWidgetApi.ts
@@ -399,6 +399,12 @@ export function mockWidgetApi(opts?: {
       room_id: options?.roomId ?? roomId,
     };
 
+    if (options?.stickyDurationMs) {
+      ev.msc4354_sticky = {
+        duration_ms: options.stickyDurationMs,
+      };
+    }
+
     if (ev.type === ROOM_EVENT_REDACTION) {
       const redactionEv = ev as RedactionRoomEvent;
       redactionEv.redacts = redactionEv.content['redacts'];


### PR DESCRIPTION
Updates `@matrix-widget-toolkit/api` and `@matrix-widget-toolkit/testing` to support MSC4354 sticky events.

Sticky events support and related APIs are experimental and could be further changed without major  `@matrix-widget-toolkit/api` release.

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [x] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
